### PR TITLE
Add project form inline to the header instead of the link to projects/new.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,4 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .
+Turbolinks.enableProgressBar();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,12 @@
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
-            <li><%= link_to 'Add a Project', new_project_path %></li>
+            <li>
+              <%= form_tag projects_path, class: 'navbar-form' do |f| %>
+                <%= text_field_tag 'project[github_url]', '', placeholder: 'Github Url', class: 'form-control' %>
+                <%= submit_tag 'Add', class: 'btn btn-default' %>
+              <% end %>
+            </li>
             <% if logged_in? %>
               <li><%= link_to current_user.nickname, '#' %></li>
               <li><%= link_to 'Logout', logout_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get 'projects/new' => 'projects#new', as: :new_project
   get 'projects/:id' => 'projects#show', as: :project
   post 'projects' => 'projects#create', as: :projects
+  get 'projects' => 'projects#index', as: :project_index
 
   get '/login',  to: 'sessions#new',     as: 'login'
   get '/logout', to: 'sessions#destroy', as: 'logout'


### PR DESCRIPTION
I also shoved in the turbolinks loading bar thing, for my own sanity.

![contrib](https://cloud.githubusercontent.com/assets/1141692/5603953/d549a022-9395-11e4-893d-37ade6cfb7e3.png)
