### PR TITLE
bump json gem version so it builds on Ubuntu

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     jquery-turbolinks (2.1.0)
       railties (>= 3.1.0)
       turbolinks
-    json (1.8.1)
+    json (1.8.2)
     jwt (1.2.0)
     kgio (2.9.2)
     listen (2.8.5)


### PR DESCRIPTION
Just a bundle install; no functional changes. Now that flori/json#231 has been merged and released