### PR TITLE
Read only JSON API for projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'github-markup', require: 'github/markup'
 gem 'redcarpet'
 gem 'pg_search'
 gem 'sprockets'
+gem 'jsonapi-resources'
 
 group :development do
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       railties (>= 3.1.0)
       turbolinks
     json (1.8.3)
+    jsonapi-resources (0.7.0)
+      rails (>= 4.0)
     jwt (1.5.2)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
@@ -305,6 +307,7 @@ DEPENDENCIES
   guard-rspec
   jquery-rails
   jquery-turbolinks
+  jsonapi-resources
   newrelic_rpm
   octokit
   omniauth

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ProjectsController < JSONAPI::ResourceController
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,8 @@ class PagesController < ApplicationController
     @issue     = @project.issues.sample
   end
 
+  def api; end
+
   private
 
   def github

--- a/app/resources/api/project_resource.rb
+++ b/app/resources/api/project_resource.rb
@@ -1,0 +1,11 @@
+module Api
+  class ProjectResource < JSONAPI::Resource
+    immutable
+
+    attributes :owner,
+               :name,
+               :name_with_owner,
+               :github_id,
+               :score
+  end
+end

--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -1,0 +1,58 @@
+<h2>JSON API</h2>
+
+<p>Follows the <%= link_to '{ json:api }', 'http://jsonapi.org/' %> spec.</p>
+
+<h3>GET Projects</h3>
+
+<pre><code>curl <%= api_projects_url %></code></pre>
+
+<p>Sort by scores</p>
+
+<pre><code>curl <%= api_projects_url(sort: '-score') %></code></pre>
+
+<pre><code>{
+  "data": [
+    {
+      "id": "1",
+      "type": "projects",
+      "links": {
+        "self": "<%= api_project_url(1) %>"
+      },
+      "attributes": {
+        "owner": "24pullrequests",
+        "name": "24pullrequests",
+        "name-with-owner": "24pullrequests/24pullrequests",
+        "github-id": 6673802,
+        "score": 38
+      }
+    }
+  ],
+  "meta": {
+    "total-records": 1
+  },
+  "links": {
+    "first": "<%= api_projects_url %>?page%5Bnumber%5D=1&page%5Bsize%5D=50",
+    "last": "<%= api_projects_url %>?page%5Bnumber%5D=1&page%5Bsize%5D=50"
+  }
+}</code></pre>
+
+<h3>GET Project</h3>
+
+<pre><code>curl <%= api_project_url(1) %></code></pre>
+
+<pre><code>{
+  "data": {
+    "id": "1",
+    "type": "projects",
+    "links": {
+      "self": "<%= api_project_url(1) %>"
+    },
+    "attributes": {
+      "owner": "24pullrequests",
+      "name": "24pullrequests",
+      "name-with-owner": "24pullrequests/24pullrequests",
+      "github-id": 6673802,
+      "score": 38
+    }
+  }
+}</code></pre>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,8 @@ module Contribulator
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    config.autoload_paths << Rails.root.join('lib/jsonapi')
+
     config.middleware.use Rack::Deflater
 
     # Do not swallow errors in after_commit/after_rollback callbacks.

--- a/config/initializers/json_api.rb
+++ b/config/initializers/json_api.rb
@@ -1,0 +1,10 @@
+JSONAPI.configure do |config|
+  config.json_key_format = :underscored_key
+
+  config.operations_processor = :counting_active_record
+
+  # Pagination
+  config.default_paginator = :paged
+  config.default_page_size = 50
+  config.maximum_page_size = 100
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   get '/about' => 'pages#about'
+  get '/api' => 'pages#api'
+
+  namespace :api do
+    jsonapi_resources :projects
+  end
 
   get 'issues/:id' => 'issues#show', as: :issue
 

--- a/lib/jsonapi/counting_active_record_operations_processor.rb
+++ b/lib/jsonapi/counting_active_record_operations_processor.rb
@@ -1,0 +1,5 @@
+class CountingActiveRecordOperationsProcessor < ActiveRecordOperationsProcessor
+  after_find_operation do
+    @operation_meta[:total_records] = @operation.record_count
+  end
+end


### PR DESCRIPTION
References #18 and https://github.com/24pullrequests/24pullrequests/issues/987

Uses https://github.com/cerebris/jsonapi-resources to implement the API.

Documentation can be found at /api
