### PR TITLE
Use github ID for the ID in the projects api

### DIFF
--- a/app/resources/api/project_resource.rb
+++ b/app/resources/api/project_resource.rb
@@ -8,17 +8,8 @@ module Api
                :github_id,
                :score
 
-    def id
-      github_id
-    end
-
-    def self.find_by_key(key, options = {})
-      context = options[:context]
-      records = records(options)
-      records = apply_includes(records, options)
-      model = records.find_by(github_id: key)
-      fail JSONAPI::Exceptions::RecordNotFound, key if model.nil?
-      resource_for_model(model).new(model, context)
+    def self._primary_key
+      :github_id
     end
   end
 end

--- a/app/resources/api/project_resource.rb
+++ b/app/resources/api/project_resource.rb
@@ -7,5 +7,18 @@ module Api
                :name_with_owner,
                :github_id,
                :score
+
+    def id
+      github_id
+    end
+
+    def self.find_by_key(key, options = {})
+      context = options[:context]
+      records = records(options)
+      records = apply_includes(records, options)
+      model = records.find_by(github_id: key)
+      fail JSONAPI::Exceptions::RecordNotFound, key if model.nil?
+      resource_for_model(model).new(model, context)
+    end
   end
 end

--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -13,10 +13,10 @@
 <pre><code>{
   "data": [
     {
-      "id": "1",
+      "id": "6673802",
       "type": "projects",
       "links": {
-        "self": "<%= api_project_url(1) %>"
+        "self": "<%= api_project_url(6673802) %>"
       },
       "attributes": {
         "owner": "24pullrequests",
@@ -38,14 +38,16 @@
 
 <h3>GET Project</h3>
 
-<pre><code>curl <%= api_project_url(1) %></code></pre>
+<p>The project ID is the github repository ID.</p>
+
+<pre><code>curl <%= api_project_url(6673802) %></code></pre>
 
 <pre><code>{
   "data": {
-    "id": "1",
+    "id": "6673802",
     "type": "projects",
     "links": {
-      "self": "<%= api_project_url(1) %>"
+      "self": "<%= api_project_url(6673802) %>"
     },
     "attributes": {
       "owner": "24pullrequests",

--- a/spec/controllers/api_projects_controller_spec.rb
+++ b/spec/controllers/api_projects_controller_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Api::ProjectsController, type: :controller do
+  describe "GET #index" do
+    let!(:project) { create(:project, github_id: 123) }
+
+    before do
+      get :index
+    end
+
+    it "status" do
+      expect(response.status).to eq(200)
+    end
+
+    it "data contains the project" do
+      expect(JSON.parse(response.body)['data'].map { |e| e['id'] }).to eq(%w(123))
+    end
+
+    it "meta total_records" do
+      expect(JSON.parse(response.body)['meta']['total_records']).to eq(1)
+    end
+  end
+
+  describe "GET #show" do
+    context 'success' do
+      let!(:project) { create(:project, github_id: 123, owner: 'jack', name: 'foo') }
+
+      before do
+        get :show, id: 123
+      end
+
+      it "responds successfully with an HTTP 200 status code" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "github_id" do
+        expect(JSON.parse(response.body)['data']['id']).to eq('123')
+      end
+
+      it "attributes" do
+        expect(JSON.parse(response.body)['data']['attributes']).to eq(
+          'owner' => 'jack',
+          'github_id' => 123,
+          'name' => 'foo',
+          'name_with_owner' => 'jack/foo',
+          'score' => 20
+        )
+      end
+
+      it "links" do
+        expect(JSON.parse(response.body)['data']['links']).to eq(
+          'self' => 'http://test.host/api/projects/123'
+        )
+      end
+    end
+
+    context '404' do
+      before do
+        get :show, id: 999
+      end
+
+      it "404" do
+        expect(response).to have_http_status(404)
+      end
+
+      it "errors" do
+        expect(JSON.parse(response.body)['errors'].first['title']).to eq('Record not found')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For consistency between projects I've updated the ID to be the github repo ID, so it can more easily be looked up here without knowing the record ID.

Also added some tests.

I couldn't find a better way of doing this with the gem so I'm using what was suggested here https://github.com/cerebris/jsonapi-resources/issues/434#issuecomment-165080640