### PR TITLE
add its-it back as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'sprockets'
 gem 'jsonapi-resources'
 gem 'sassc-rails'
 gem 'schema_plus_pg_indexes'
+gem 'its-it'
 
 group :development do
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,6 +342,7 @@ DEPENDENCIES
   guard-bundler
   guard-migrate
   guard-rspec
+  its-it
   jquery-rails
   jquery-turbolinks
   jsonapi-resources


### PR DESCRIPTION
Fixes the upgrade of `schema_plus_pg_indexes` in https://github.com/andrew/contribulator/commit/b1ddadb3dd899f834e0bef042419bd35cbf1244f